### PR TITLE
fixes an issue where an incorrect document path was returned

### DIFF
--- a/Export Click Dummy.sketchplugin
+++ b/Export Click Dummy.sketchplugin
@@ -3,7 +3,7 @@
 #import 'library.js'
 #import 'sandbox.js'
 
-var documentPath = [[doc fileURL] path].split([doc displayName])[0];
+var documentPath = [[doc fileURL] path].split([doc displayName] + ".sketch")[0];
 
 new AppSandbox().authorize(documentPath, exportClickDummy);
 


### PR DESCRIPTION
For the case rare when your filename has the same name as its folder, the plugin would use the parent folder.

For example in "test/test.sketch" the method String.split([doc displayName] would actually match the folder instead of the filename that you want to get rid of.