### PR TITLE
Combine plugins

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+README.md export-ignore
+LICENSE.md export-ignore
+.gitattributes export-ignore

--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ Exports a simple HTML click dummy so you can easily prototype flows between your
 ![Sketch Click Dummy](https://cloud.githubusercontent.com/assets/418877/5471648/6ff1f756-85f8-11e4-9645-05e76d699709.png)
 
 # Installation
-Download this plugin and [put it in your Sketch plugins folder](http://bohemiancoding.com/sketch/support/developer/01-introduction/01.html).
+1. Download this plugin
+2. Create a folder called "Click Dummy" in your [plugins folder](http://bohemiancoding.com/sketch/support/developer/01-introduction/01.html)
+3. Put the contents of the downloaded folder into the created one
+4. Re-start Sketch
 
 # How to use
 - To create a link placeholder, draw a rectangle and rename it to _linkto:ArtboardName_.


### PR DESCRIPTION
A user doesn't need all those ".md" files when downloading the plugin from GitHub. If you ask me, it's also better to combine both plugins under one name.